### PR TITLE
docs: 统一品牌名称为 CloudGramStore

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 CloudGram Store
+Copyright (c) 2023 CloudGramStore
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,4 +1,4 @@
-/* CloudGram Store 样式文件 */
+/* CloudGramStore 样式文件 */
 
 /* 全局样式 */
 * {

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CloudGram Store - 个人文件存储</title>
+    <title>CloudGramStore - 个人文件存储</title>
 
     <!-- Ant Design CSS -->
     <!-- <link href="https://cdn.jsdelivr.net/npm/antd@5.12.8/dist/reset.css" rel="stylesheet"> -->
@@ -20,7 +20,7 @@
     <div id="loginPage" class="login-container">
         <div class="login-box">
             <div class="login-header">
-                <h1>CloudGram Store</h1>
+                <h1>CloudGramStore</h1>
                 <p>基于 Cloudflare + Telegram 的个人文件存储</p>
             </div>
             <form id="loginForm" class="login-form">
@@ -43,7 +43,7 @@
         <!-- 头部导航 -->
         <header class="header">
             <div class="header-left">
-                <h1 class="header-title">CloudGram Store</h1>
+                <h1 class="header-title">CloudGramStore</h1>
             </div>
             <div class="header-right">
                 <span id="currentUser" class="user-info"></span>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,4 +1,4 @@
-// CloudGram Store 主 JavaScript 文件
+// CloudGramStore 主 JavaScript 文件
 // 模块化前端应用入口
 
 import { AuthManager } from './modules/auth.js';

--- a/public/js/modules/uiManager.js
+++ b/public/js/modules/uiManager.js
@@ -313,7 +313,7 @@ export class UIManager {
      * 设置页面标题
      */
     setPageTitle(title) {
-        document.title = title ? `${title} - CloudGram Store` : 'CloudGram Store';
+        document.title = title ? `${title} - CloudGramStore` : 'CloudGramStore';
     }
 
     /**

--- a/schema.sql
+++ b/schema.sql
@@ -1,4 +1,4 @@
--- CloudGram Store 数据库结构
+-- CloudGramStore 数据库结构
 -- 用于 Cloudflare D1 数据库
 
 -- 文件夹表


### PR DESCRIPTION
将代码中所有出现的 "CloudGram Store" 统一修改为 "CloudGramStore"，保持品牌名称一致性